### PR TITLE
dependency fix: numpy version must be compatible with numba

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ py_versions = "2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3
 
 requirements = [
     "numba==0.55.0",
-    "numpy>=1.18.0,<=1.22.0",
+    "numpy>=1.18.0,<1.22.0",
     "pandas<=1.2.5",
     "pathlib",
     "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ py_versions = "2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3
 
 requirements = [
     "numba==0.55.0",
-    "numpy>=1.21.0",
+    "numpy>=1.18.0,<=1.22.0",
     "pandas<=1.2.5",
     "pathlib",
     "matplotlib",


### PR DESCRIPTION
numba 0.55 needs numpy version between 1.18-1.22. 
See: https://github.com/numba/numba/blob/release0.55/setup.py#L25-L26

The current numpy requirements in `setup.py` lead to errors during install and when trying to run.

With the numpy constriants in this PR everything installs and runs fine for me, tested via `pip install -e .`

I am on ubuntu focal, python 3.8
