### PR TITLE
the minimum pandas version must be 1.4.0. In earlier versions, an err…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ py_versions = "2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3
 
 requirements = [
     "numba==0.55.0",
-    "numpy>=1.18.0,<1.22.0",
-    "pandas",
+    "numpy>=1.18.0,<=1.22.3",
+    "pandas>=1.4.0",
     "pathlib",
     "matplotlib",
     "seaborn",

--- a/setup.py
+++ b/setup.py
@@ -50,13 +50,12 @@ statuses = [
     "6 - Mature",
     "7 - Inactive",
 ]
-py_versions = "2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8".split()
+py_versions = "3.4 3.5 3.6 3.7 3.8".split()
 
 requirements = [
     "numba==0.55.0",
     "numpy>=1.18.0,<=1.22.3",
     "pandas>=1.4.0",
-    "pathlib",
     "matplotlib",
     "seaborn",
 ]


### PR DESCRIPTION
A bug appears when using panda versions earlier than 1.4.0. 
The error appears when running irrigation method 3 (shedule). 

I was following the example number 2. [Estimation of irrigation water demands](https://colab.research.google.com/github/aquacropos/aquacrop/blob/master/docs/notebooks/AquaCrop_OSPy_Notebook_2.ipynb)

The error log is:
```

Traceback (most recent call last):
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/tests/test_irrigation.py", line 37, in test_predefined_schedule_strategy
    model.initialize()
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/aquacrop/core.py", line 150, in initialize
    self.ParamStruct = read_irrigation_management(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/aquacrop/initialize.py", line 305, in read_irrigation_management
    df = df.reindex(ClockStruct.TimeSpan, fill_value=0).drop("Date", axis=1)
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/util/_decorators.py", line 324, in wrapper
    return func(*args, **kwargs)
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/frame.py", line 4767, in reindex
    return super().reindex(**kwargs)
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/generic.py", line 4809, in reindex
    return self._reindex_axes(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/frame.py", line 4592, in _reindex_axes
    frame = frame._reindex_index(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/frame.py", line 4611, in _reindex_index
    return self._reindex_with_indexers(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/generic.py", line 4874, in _reindex_with_indexers
    new_data = new_data.reindex_indexer(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/internals/managers.py", line 673, in reindex_indexer
    new_blocks = [
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/internals/managers.py", line 674, in <listcomp>
    blk.take_nd(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/internals/blocks.py", line 1145, in take_nd
    new_values = algos.take_nd(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/array_algos/take.py", line 101, in take_nd
    return arr.take(
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/arrays/_mixins.py", line 97, in take
    fill_value = self._validate_scalar(fill_value)
  File "/Users/pacopuig/Desktop/PROGRAMACION/aquacrop/aquacrop/venv/lib/python3.9/site-packages/pandas/core/arrays/datetimelike.py", line 645, in _validate_scalar
    raise TypeError(msg)
TypeError: value should be a 'Timestamp' or 'NaT'. Got 'int' instead.

```
Maybe this error has to do with the bug [42921](https://github.com/pandas-dev/pandas/issues/42921) that was fixed in pandas version 1.4.


