### PR TITLE
Fixing bugs with groundwater, irrigation, soil bunds, canopy and root development

### DIFF
--- a/aquacrop/entities/fieldManagement.py
+++ b/aquacrop/entities/fieldManagement.py
@@ -19,7 +19,7 @@ class FieldMngt:
 
         f_mulch (float): Soil evaporation adjustment factor due to effect of mulches
 
-        z_bund (float): Bund height (m)
+        z_bund (float): Bund height, user specifies in (m) but immediately converted to (mm) on initialisation for coherent calculations
 
         bund_water (float): Initial water height in surface bunds (mm)
 
@@ -47,7 +47,7 @@ class FieldMngt:
 
         self.mulch_pct = mulch_pct  #  Area of soil surface covered by mulches (%)
         self.f_mulch = f_mulch  # Soil evaporation adjustment factor due to effect of mulches
-        self.z_bund = z_bund  # Bund height (m)
+        self.z_bund = z_bund * 1000 # Bund height, user-specified as (m), here immediately converted to (mm)
         self.bund_water = bund_water  # Initial water height in surface bunds (mm)
         self.curve_number_adj_pct = curve_number_adj_pct  # Percentage change in curve number (positive or negative)
 

--- a/aquacrop/solution/HIref_current_day.py
+++ b/aquacrop/solution/HIref_current_day.py
@@ -103,59 +103,55 @@ def HIref_current_day(
             NewCond_HIref = 0
             NewCond_PctLagPhase = 0
         else:
-            if NewCond_CC_prev <= (Crop.CCmin*Crop.CCx):
-                # HI cannot develop further as canopy cover is too small
-                NewCond_HIref = InitCond_HIref
-            else:
-                # Check crop type
-                if (Crop.CropType == 1) or (Crop.CropType == 2):
-                    # If crop type is leafy vegetable or root/tuber, then proceed with
-                    # logistic growth (i.e. no linear switch)
-                    NewCond_PctLagPhase = 100  # No lag phase
+            # Check crop type
+            if (Crop.CropType == 1) or (Crop.CropType == 2):
+                # If crop type is leafy vegetable or root/tuber, then proceed with
+                # logistic growth (i.e. no linear switch)
+                NewCond_PctLagPhase = 100  # No lag phase
+                # Calculate reference harvest index for current day
+                NewCond_HIref = (Crop.HIini * Crop.HI0) / (
+                    Crop.HIini + (Crop.HI0 - Crop.HIini) * np.exp(-Crop.HIGC * HIt))
+                # Harvest index apprAOSP_hing maximum limit
+                if NewCond_HIref >= (0.9799 * Crop.HI0):
+                    NewCond_HIref = Crop.HI0
+
+            elif Crop.CropType == 3:
+                # If crop type is fruit/grain producing, check for linear switch
+                if HIt < Crop.tLinSwitch:
+                    # Not yet reached linear switch point, therefore proceed with
+                    # logistic build-up
+                    NewCond_PctLagPhase = 100 * (HIt / Crop.tLinSwitch)
                     # Calculate reference harvest index for current day
+                    # (logistic build-up)
                     NewCond_HIref = (Crop.HIini * Crop.HI0) / (
                         Crop.HIini + (Crop.HI0 - Crop.HIini) * np.exp(-Crop.HIGC * HIt))
-                    # Harvest index apprAOSP_hing maximum limit
-                    if NewCond_HIref >= (0.9799 * Crop.HI0):
-                        NewCond_HIref = Crop.HI0
-    
-                elif Crop.CropType == 3:
-                    # If crop type is fruit/grain producing, check for linear switch
-                    if HIt < Crop.tLinSwitch:
-                        # Not yet reached linear switch point, therefore proceed with
-                        # logistic build-up
-                        NewCond_PctLagPhase = 100 * (HIt / Crop.tLinSwitch)
-                        # Calculate reference harvest index for current day
-                        # (logistic build-up)
-                        NewCond_HIref = (Crop.HIini * Crop.HI0) / (
-                            Crop.HIini + (Crop.HI0 - Crop.HIini) * np.exp(-Crop.HIGC * HIt))
-                    else:
-                        # Linear switch point has been reached
-                        NewCond_PctLagPhase = 100
-                        # Calculate reference harvest index for current day
-                        # (logistic portion)
-                        NewCond_HIref = (Crop.HIini * Crop.HI0) / (Crop.HIini
-                            + (Crop.HI0 - Crop.HIini) * np.exp(-Crop.HIGC * Crop.tLinSwitch))
-                        # Calculate reference harvest index for current day
-                        # (total - logistic portion + linear portion)
-                        NewCond_HIref = NewCond_HIref + (Crop.dHILinear * (HIt - Crop.tLinSwitch))
-    
-                # Limit hi_ref and round off computed value
-                if NewCond_HIref > Crop.HI0:
-                    NewCond_HIref = Crop.HI0
-                elif NewCond_HIref <= (Crop.HIini + 0.004):
-                    NewCond_HIref = 0
-                elif (Crop.HI0 - NewCond_HIref) < 0.004:
-                    NewCond_HIref = Crop.HI0
-                
-                # Adjust hi_ref for inadequate photosynthesis
-                if (NewCond_HIfinal == Crop.HI0) and (HIt <= Crop.YldFormCD) and (NewCond_CC <= 0.05) and (
-                    NewCond_CCxW > 0) and (NewCond_CC < NewCond_CCxW) and (Crop.CropType==2 or Crop.CropType==3):
-    
-                    NewCond_HIfinal = NewCond_HIref
-                
-                if NewCond_HIref > NewCond_HIfinal:
-                    NewCond_HIref = NewCond_HIfinal
+                else:
+                    # Linear switch point has been reached
+                    NewCond_PctLagPhase = 100
+                    # Calculate reference harvest index for current day
+                    # (logistic portion)
+                    NewCond_HIref = (Crop.HIini * Crop.HI0) / (Crop.HIini
+                        + (Crop.HI0 - Crop.HIini) * np.exp(-Crop.HIGC * Crop.tLinSwitch))
+                    # Calculate reference harvest index for current day
+                    # (total - logistic portion + linear portion)
+                    NewCond_HIref = NewCond_HIref + (Crop.dHILinear * (HIt - Crop.tLinSwitch))
+
+            # Limit hi_ref and round off computed value
+            if NewCond_HIref > Crop.HI0:
+                NewCond_HIref = Crop.HI0
+            elif NewCond_HIref <= (Crop.HIini + 0.004):
+                NewCond_HIref = 0
+            elif (Crop.HI0 - NewCond_HIref) < 0.004:
+                NewCond_HIref = Crop.HI0
+            
+            # Adjust hi_ref for inadequate photosynthesis
+            if (NewCond_HIfinal == Crop.HI0) and (HIt <= Crop.YldFormCD) and (NewCond_CC <= 0.05) and (
+                NewCond_CCxW > 0) and (NewCond_CC < NewCond_CCxW) and (Crop.CropType==2 or Crop.CropType==3):
+
+                NewCond_HIfinal = NewCond_HIref
+            
+            if NewCond_HIref > NewCond_HIfinal:
+                NewCond_HIref = NewCond_HIfinal
 
     else:
         # Reference harvest index is zero outside of growing season

--- a/aquacrop/solution/check_groundwater_table.py
+++ b/aquacrop/solution/check_groundwater_table.py
@@ -121,9 +121,9 @@ def check_groundwater_table(
         # Store adjusted field capacity values
         NewCond_th_fc_Adj = thfcAdj
         # prof.th_fc_Adj = thfcAdj
-        return (NewCond_th_fc_Adj, NewCond_WTinSoil)
+        return (NewCond_th_fc_Adj, NewCond_WTinSoil, NewCond_zGW)
 
-    return (NewCond_th_fc_Adj, None)
+    return (NewCond_th_fc_Adj, None, None)
 
 if __name__ == "__main__":
     cc.compile()

--- a/aquacrop/solution/infiltration.py
+++ b/aquacrop/solution/infiltration.py
@@ -130,11 +130,11 @@ def infiltration(
                     NewCond_SurfaceStorage = 0
 
                 # Calculate additional runoff
-                if NewCond_SurfaceStorage > (FieldMngt_zBund * 1000):
+                if NewCond_SurfaceStorage > FieldMngt_zBund:
                     # Water overtops bunds and runs off
-                    RunoffIni = NewCond_SurfaceStorage - (FieldMngt_zBund * 1000)
+                    RunoffIni = NewCond_SurfaceStorage - FieldMngt_zBund
                     # Surface storage equal to bund height
-                    NewCond_SurfaceStorage = FieldMngt_zBund * 1000
+                    NewCond_SurfaceStorage = FieldMngt_zBund * 1
                 else:
                     # No overtopping of bunds
                     RunoffIni = 0
@@ -286,11 +286,11 @@ def infiltration(
                 # Increase surface storage
                 NewCond_SurfaceStorage = NewCond_SurfaceStorage + (Runoff - RunoffIni)
                 # Limit surface storage to bund height
-                if NewCond_SurfaceStorage > (FieldMngt_zBund * 1000):
+                if NewCond_SurfaceStorage > FieldMngt_zBund:
                     # Additonal water above top of bunds becomes runoff
-                    Runoff = RunoffIni + (NewCond_SurfaceStorage - (FieldMngt_zBund * 1000))
+                    Runoff = RunoffIni + (NewCond_SurfaceStorage - FieldMngt_zBund)
                     # Set surface storage to bund height
-                    NewCond_SurfaceStorage = FieldMngt_zBund * 1000
+                    NewCond_SurfaceStorage = FieldMngt_zBund * 1
                 else:
                     # No additional overtopping of bunds
                     Runoff = RunoffIni

--- a/aquacrop/solution/infiltration.py
+++ b/aquacrop/solution/infiltration.py
@@ -290,7 +290,7 @@ def infiltration(
                     # Additonal water above top of bunds becomes runoff
                     Runoff = RunoffIni + (NewCond_SurfaceStorage - FieldMngt_zBund)
                     # Set surface storage to bund height
-                    NewCond_SurfaceStorage = FieldMngt_zBund * 1
+                    NewCond_SurfaceStorage = FieldMngt_zBund
                 else:
                     # No additional overtopping of bunds
                     Runoff = RunoffIni

--- a/aquacrop/solution/irrigation.py
+++ b/aquacrop/solution/irrigation.py
@@ -175,8 +175,8 @@ def irrigation(
                 EffAdj = ((100 - IrrMngt_AppEff) + 100) / 100
                 IrrReq = IrrReq * EffAdj
                 # Limit irrigation to maximum depth
-                # Irr = min(IrrMngt_MaxIrr, IrrReq)
-                Irr = 15 # hard-code in 15mm depth for tests
+                Irr = min(IrrMngt_MaxIrr, IrrReq)
+                # Irr = 15 # hard-code in 15mm depth for tests
             else:
                 Irr = 0
 

--- a/aquacrop/solution/root_development.py
+++ b/aquacrop/solution/root_development.py
@@ -272,7 +272,7 @@ def root_development(
         # No root system outside of the growing season
         NewCond_Zroot = 0
 
-    return NewCond_Zroot
+    return NewCond_Zroot, NewCond_rCor
 
 if __name__ == "__main__":
     cc.compile()

--- a/aquacrop/timestep/run_single_timestep.py
+++ b/aquacrop/timestep/run_single_timestep.py
@@ -179,7 +179,7 @@ def solution_single_time_step(
 
     # Run simulations %%
     # 1. Check for groundwater table
-    NewCond.th_fc_Adj, NewCond.wt_in_soil = check_groundwater_table(
+    NewCond.th_fc_Adj, NewCond.wt_in_soil, NewCond.z_gw = check_groundwater_table(
         Soil.Profile,
         NewCond.z_gw,
         NewCond.th,
@@ -189,7 +189,7 @@ def solution_single_time_step(
     )
 
     # 2. Root development
-    NewCond.z_root = root_development(
+    NewCond.z_root, NewCond.r_cor = root_development(
         Crop,
         Soil.Profile,
         NewCond.dap,
@@ -270,7 +270,7 @@ def solution_single_time_step(
         NewCond.th,
         NewCond.surface_storage,
         DeepPerc,
-        Runoff,
+        RunoffTot,
         Infl,
         FluxOut,
     ) = infiltration(
@@ -396,8 +396,8 @@ def solution_single_time_step(
         NewCond.delayed_cds,
         NewCond.yield_form,
         NewCond.pct_lag_phase,
-        #NewCond.cc_prev,
         NewCond.canopy_cover,
+        NewCond.cc_prev,
         NewCond.ccx_w,
         Crop,
         growing_season,

--- a/aquacrop/timestep/run_single_timestep.py
+++ b/aquacrop/timestep/run_single_timestep.py
@@ -270,7 +270,7 @@ def solution_single_time_step(
         NewCond.th,
         NewCond.surface_storage,
         DeepPerc,
-        RunoffTot,
+        Runoff,
         Infl,
         FluxOut,
     ) = infiltration(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aquacrop
-version = 3.0.8
+version = 3.0.9
 author = Tim Foster
 author_email = timothy.foster@manchester.ac.uk
 description = Soil-Crop-Water model based on AquaCrop-OS.


### PR DESCRIPTION
I was comparing AquaCrop-OSPy based on AquaCrop v6.1 (2022) vs v7.0 (2024) and found several bugs including:

1. check_groundwater_table.py doesn't return NewCond_zGW variable leading to constant groundwater levels (see #99)
2. HIref_current_day.py doesn't check for NewCond_CC_prev <= (Crop.CCmin*Crop.CCx) condition as it used to do in AquaCrop-OSPy v6.1 (perhaps it's how new AquaCrop v7 works, please confirm)
3. irrigation.py has hardcoded 15mm irrigation for IrrMngt_IrrMethod == 1 (see #132)
4. root_development.py doesn't return NewCond_rCor which is supposed to be updated daily according to AquaCrop-OSPy v6.1
5. infiltration.py has soil bunds multiplied by 1000, although they are provided in mm already