### PR TITLE
bug/root_growth

### DIFF
--- a/aquacrop/solution/root_development.py
+++ b/aquacrop/solution/root_development.py
@@ -176,7 +176,7 @@ def root_development(
                     deltaZ = soil_layer_dz
 
             # Correct Zr and dZr for effects of restrictive horizons
-            Zr = ZrOUT
+            Zr = max(ZrOUT, ZrOld)
             dZr = Zr - ZrOld
 
         # Adjust rate of expansion for any stomatal water stress

--- a/tests/test_rootgowth.py
+++ b/tests/test_rootgowth.py
@@ -1,0 +1,87 @@
+"""
+This test is for bug testing
+"""
+import os
+os.environ['DEVELOPMENT'] = 'True'
+import unittest
+
+from aquacrop import AquaCropModel, Soil, Crop, InitialWaterContent, GroundWater
+from aquacrop.utils import prepare_weather, get_filepath
+
+
+
+
+class TestModelExceptions(unittest.TestCase):
+    """
+    Test of what happens if the model does not run.
+    """
+
+    _weather_file_path = get_filepath("tunis_climate.txt")
+
+    _weather_data = prepare_weather(_weather_file_path)
+
+    _weather_data["Precipitation"] = (
+        _weather_data["Precipitation"] / 10
+    )  # too much rain for ground water effect in the original
+
+    # create a custom soil that has a layer with penetrability = 0
+    soil_custom3 = Soil(soil_type='custom', cn=46, rew=7)
+    soil_custom3.add_layer(thickness=.1*3,thWP=0.24,
+                            thFC=0.40,thS=0.50,Ksat=155,
+                            penetrability=100)
+    soil_custom3.add_layer(thickness=.1*3,thWP=0.24,
+                            thFC=0.40,thS=0.50,Ksat=155,
+                            penetrability=100)
+    soil_custom3.add_layer(thickness=.1*3,thWP=0.24,
+                            thFC=0.40,thS=0.50,Ksat=155,
+                            penetrability=100)
+    soil_custom3.add_layer(thickness=.1*3,thWP=0.24,
+                            thFC=0.40,thS=0.50,Ksat=155,
+                            penetrability=0)
+    print(soil_custom3.profile) 
+    _wheat = Crop("Wheat", planting_date="10/01")
+    _initial_water_content = InitialWaterContent(value=["FC"])
+    _model_os = AquaCropModel(
+        sim_start_time=f"{1979}/10/01",
+        sim_end_time=f"{1981}/05/30",
+        weather_df=_weather_data,
+        soil=soil_custom3,
+        crop=_wheat,
+        initial_water_content=_initial_water_content,
+        groundwater=GroundWater(
+            water_table="Y", dates=[f"{1979}/10/01"], values=[2.66]
+        ),
+    )
+    _model_os.run_model(till_termination=True)
+
+    def test_minimum_root_depth(self):
+        """
+        Test that minimum root depth is not below 0
+        """
+        root_depth = self._model_os._outputs.crop_growth["z_root"]
+    
+        min_rooting_depth_expected = 0
+        min_rooting_depth_returned = round(root_depth.min(), 1)
+        self.assertEqual(min_rooting_depth_expected, min_rooting_depth_returned)
+    
+    def test_maximum_root_depth(self):
+        """
+        Test that minimum root depth is not below 0
+        """
+        root_depth = self._model_os._outputs.crop_growth["z_root"]
+    
+        max_rooting_depth_expected = 0.9
+        max_rooting_depth_returned = round(root_depth.max(), 1)
+        self.assertEqual(max_rooting_depth_expected, max_rooting_depth_returned)
+    
+    def test_root_depth(self):
+        """
+        Test that root depth does not decrease through time
+        """
+        root_depth = self._model_os._outputs.crop_growth["z_root"]
+    
+        for earlier,later in zip(root_depth, root_depth[1:]):
+            self.assertGreaterEqual(later, earlier, "Root depth decreased through time")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rootgowth.py
+++ b/tests/test_rootgowth.py
@@ -38,12 +38,12 @@ class TestModelExceptions(unittest.TestCase):
     soil_custom3.add_layer(thickness=.1*3,thWP=0.24,
                             thFC=0.40,thS=0.50,Ksat=155,
                             penetrability=0)
-    print(soil_custom3.profile) 
+    #print(soil_custom3.profile) 
     _wheat = Crop("Wheat", planting_date="10/01")
     _initial_water_content = InitialWaterContent(value=["FC"])
     _model_os = AquaCropModel(
         sim_start_time=f"{1979}/10/01",
-        sim_end_time=f"{1981}/05/30",
+        sim_end_time=f"{1980}/05/30",
         weather_df=_weather_data,
         soil=soil_custom3,
         crop=_wheat,
@@ -58,9 +58,11 @@ class TestModelExceptions(unittest.TestCase):
         """
         Test that minimum root depth is not below 0
         """
-        root_depth = self._model_os._outputs.crop_growth["z_root"]
+        harvest_time_step = self._model_os._outputs.final_stats['Harvest Date (Step)'].values[0]
+        crop_growth = self._model_os._outputs.crop_growth
+        root_depth = crop_growth["z_root"][0:harvest_time_step]
     
-        min_rooting_depth_expected = 0
+        min_rooting_depth_expected = 0.3
         min_rooting_depth_returned = round(root_depth.min(), 1)
         self.assertEqual(min_rooting_depth_expected, min_rooting_depth_returned)
     
@@ -68,7 +70,9 @@ class TestModelExceptions(unittest.TestCase):
         """
         Test that minimum root depth is not below 0
         """
-        root_depth = self._model_os._outputs.crop_growth["z_root"]
+        harvest_time_step = self._model_os._outputs.final_stats['Harvest Date (Step)'].values[0]
+        crop_growth = self._model_os._outputs.crop_growth[self._model_os._outputs.crop_growth['time_step_counter'] <= harvest_time_step]
+        root_depth = crop_growth["z_root"][0:harvest_time_step]
     
         max_rooting_depth_expected = 0.9
         max_rooting_depth_returned = round(root_depth.max(), 1)
@@ -78,7 +82,9 @@ class TestModelExceptions(unittest.TestCase):
         """
         Test that root depth does not decrease through time
         """
-        root_depth = self._model_os._outputs.crop_growth["z_root"]
+        harvest_time_step = self._model_os._outputs.final_stats['Harvest Date (Step)'].values[0]
+        crop_growth = self._model_os._outputs.crop_growth[self._model_os._outputs.crop_growth['time_step_counter'] <= harvest_time_step]
+        root_depth = crop_growth["z_root"][0:harvest_time_step]
     
         for earlier,later in zip(root_depth, root_depth[1:]):
             self.assertGreaterEqual(later, earlier, "Root depth decreased through time")

--- a/tests/test_rootgowth.py
+++ b/tests/test_rootgowth.py
@@ -56,7 +56,7 @@ class TestModelExceptions(unittest.TestCase):
 
     def test_minimum_root_depth(self):
         """
-        Test that minimum root depth is not below 0
+        Test that minimum root depth is not below 0.3.
         """
         harvest_time_step = self._model_os._outputs.final_stats['Harvest Date (Step)'].values[0]
         crop_growth = self._model_os._outputs.crop_growth
@@ -68,7 +68,7 @@ class TestModelExceptions(unittest.TestCase):
     
     def test_maximum_root_depth(self):
         """
-        Test that minimum root depth is not below 0
+        Test that maximum root depth is not greater than the depth where penetrability = 0.
         """
         harvest_time_step = self._model_os._outputs.final_stats['Harvest Date (Step)'].values[0]
         crop_growth = self._model_os._outputs.crop_growth[self._model_os._outputs.crop_growth['time_step_counter'] <= harvest_time_step]
@@ -80,7 +80,7 @@ class TestModelExceptions(unittest.TestCase):
     
     def test_root_depth(self):
         """
-        Test that root depth does not decrease through time
+        Test that root depth does not decrease through time.
         """
         harvest_time_step = self._model_os._outputs.final_stats['Harvest Date (Step)'].values[0]
         crop_growth = self._model_os._outputs.crop_growth[self._model_os._outputs.crop_growth['time_step_counter'] <= harvest_time_step]


### PR DESCRIPTION
When a root restricting soil layer was present (penetrability =0), root depth began decreasing after the restricted layer was reached. To ensure the behavior of root growth in response to a root restricting soil layer matched the expected behavior of aquacrop, where root depth does not decrease through time (https://[openknowledge.fao.org/server/api/core/bitstreams/3c388b6e-5e99-4da3-b457-8becb9b926d7/content#page=17.09](https://openknowledge.fao.org/server/api/core/bitstreams/3c388b6e-5e99-4da3-b457-8becb9b926d7/content#page=17.09))), root depth was set to return the maximum of the current (new) root depth or yesterday's root depth.

This issue is illustrated with the test script tests/test_rootgrowth.py. There are three test functions. test_minimum_root_depth() ensures the minimum root depth is 0.3 (the default of the crop used in the test simulation). test_maximimum_root_depth() ensures that maximum rooting depth is 0.9 (the depth of soil layer where penetrability =0 in the custom soil used in the simulation). test_root_depth() ensures that root depth does not decrease through time. 

The test fails when line 179 of root_development.py is: Zr = ZrOUT. The test passes when line 179 of root_development.py is: Zr = max(ZrOUT, ZrOld).